### PR TITLE
Remove optional example dirs from makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -119,7 +119,10 @@ $(if $(word 2,$(SRC)),$(error Spaces in SRC = "$(SRC)" are not supported))
 MFEM_GIT_STRING = $(shell [ -d $(MFEM_DIR)/.git ] && git -C $(MFEM_DIR) \
    describe --all --long --abbrev=40 --dirty --always 2> /dev/null)
 
-EXAMPLE_SUBDIRS = amgx caliper ginkgo hiop petsc pumi sundials superlu moonolith
+# List of example subdirectories that require optional third-party packages.
+# These directories are not distributed with this repository, so avoid
+# descending into them by default.
+EXAMPLE_SUBDIRS =
 EXAMPLE_DIRS := examples $(addprefix examples/,$(EXAMPLE_SUBDIRS))
 EXAMPLE_TEST_DIRS := examples
 


### PR DESCRIPTION
## Summary
- avoid entering non-existent optional example directories

## Testing
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_68683141e6cc832ca01ea9343330579d